### PR TITLE
dog情報新規登録処理の修正

### DIFF
--- a/app/controllers/dog_profiles_controller.rb
+++ b/app/controllers/dog_profiles_controller.rb
@@ -2,7 +2,9 @@ class DogProfilesController < ApplicationController
   before_action :move_to_index
   before_action :set_params, only: [:edit, :update, :destroy]
   before_action :compare_id, only: [:edit]
-  before_action :date_check, only: [:create, :update]
+  before_action :set_date, only: [:create, :update_date_check]
+  before_action :create_date_check, only: [:create]
+  before_action :update_date_check, only: [:update]
 
   def new
     @dog_profile = DogProfile.new
@@ -59,30 +61,60 @@ class DogProfilesController < ApplicationController
     end
   end
 
-  def date_check
-    year = params[:dog_profile]["dog_birthday(1i)"].to_i
-    month = params[:dog_profile]["dog_birthday(2i)"].to_i
-    day = params[:dog_profile]["dog_birthday(3i)"].to_i
+  def set_date
+    @year = params[:dog_profile]["dog_birthday(1i)"].to_i
+    @month = params[:dog_profile]["dog_birthday(2i)"].to_i
+    @day = params[:dog_profile]["dog_birthday(3i)"].to_i
+  end
 
-    if year.zero? || month.zero? || day.zero?
-      if (year.zero? && month.zero? && day.zero?) && @dog_profile.update(profile_params)
+  def create_date_check
+    @dog_profile = DogProfile.new(profile_params)
+    if @year.zero? || @month.zero? || @day.zero?
+      if (@year.zero? && @month.zero? && @day.zero?) && @dog_profile.save
         redirect_to user_path(current_user.id)
       else
-        flash[:notice] = "存在しない日付が入力されています"
+        flash[:notice] = "正しい日付を入力してください"
+        render :new
+      end
+      return
+    end
+
+    begin
+      dog_birthday = Date.new(@year, @month, @day)
+    rescue ArgumentError, TypeError
+      flash[:notice] = "存在しない日付が入力されています"
+      render :new
+      return
+    end
+
+    dog_birthday = Date.new(@year, @month, @day)
+    if dog_birthday > Date.today
+      flash[:notice] = "日付が未来日です"
+      render :new
+      return
+    end
+  end
+
+  def update_date_check
+    if @year.zero? || @month.zero? || @day.zero?
+      if (@year.zero? && @month.zero? && @day.zero?) && @dog_profile.update(profile_params)
+        redirect_to user_path(current_user.id)
+      else
+        flash[:notice] = "正しい日付を入力してください"
         render :edit
       end
       return
     end
 
     begin
-      dog_birthday = Date.new(year, month, day)
+      dog_birthday = Date.new(@year, @month, @day)
     rescue ArgumentError, TypeError
       flash[:notice] = "存在しない日付が入力されています"
       render :edit
       return
     end
 
-    dog_birthday = Date.new(year, month, day)
+    dog_birthday = Date.new(@year, @month, @day)
     if dog_birthday > Date.today
       flash[:notice] = "日付が未来日です"
       render :edit


### PR DESCRIPTION
# What
飼犬情報新規登録処理の生年月日の登録条件分岐修正
# Why
生年月日が全て未選択の場合正常に登録でき、一部未選択の場合、未来日の場合、存在しない日付の場合はエラーが出力され登録されないようにするため
